### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -37,7 +37,7 @@ const clientDistPath = path.join(__dirname, '..', 'client', 'dist');
 app.use(express.static(clientDistPath));
 
 // Catch-all for client-side routing
-app.get('*', (req, res) => {
+app.get('*', limiter, (req, res) => {
   res.sendFile(path.join(clientDistPath, 'index.html'));
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/joblas/dall-e/security/code-scanning/3](https://github.com/joblas/dall-e/security/code-scanning/3)

To address the issue, we will apply the existing rate limiter (`limiter`) to the catch-all route (`*`) in addition to the `/api/v1` routes. This ensures that all requests to the server, including those that serve static files, are rate-limited. The fix involves adding the `limiter` middleware to the catch-all route on line 40.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
